### PR TITLE
Tweet resolutions

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,0 +1,17 @@
+class TweetsController < ApplicationController
+  def create
+    tweet_body = "My new resolution is: #{resolution.title}!"
+    send_tweet(body: tweet_body)
+    redirect_to dashboard_path, flash: { notice: "Tweeted successfully!" }
+  end
+
+  private
+
+  def resolution
+    @_resolution ||= Resolution.find(params[:resolution_id])
+  end
+
+  def send_tweet(body:)
+    current_user.twitter_client.update(body)
+  end
+end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -44,6 +44,7 @@
                 <a href="">Share</a>
                 <%= link_to "Delete", resolution_path(resolution), method: :delete , data: {confirm: "This will remove your resolution. Are you sure?"} %>
                 <%= link_to "Add Goal", new_goal_path %>
+                <%= link_to "Tweet This", resolution_tweets_path(resolution), method: :post %>
             </div>
         </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
 
   resources :users, except: [:destroy]
 
-  resources :resolutions
+  resources :resolutions do
+    resources :tweets, only: [:create]
+  end
 
   resources :goals
 end

--- a/spec/features/tweet_resolution_spec.rb
+++ b/spec/features/tweet_resolution_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+feature 'User tweets resolution' do
+  scenario 'successfully' do
+    stub_twitter_timeline
+    user = sign_in_with_twitter
+    user.resolutions.create!(
+      title: "Get better at testing",
+      description: "TDD is great!",
+    )
+
+    visit dashboard_path
+    tweet_resolution_name
+
+    expect(page).to have_content("Tweeted successfully!")
+    expect_tweet_to_be_posted_to_twitter(
+      body: "My new resolution is: Get better at testing!",
+    )
+  end
+
+  private
+
+  def sign_in_with_twitter
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({
+      provider: 'twitter',
+      uid: '123545',
+      extra: {
+        raw_info: {
+          name: "David",
+          profile_image_url: "http://placehold.it/100x100",
+        },
+      },
+      credentials: {
+        token: "token",
+        secret: "secret",
+      },
+    })
+    visit root_path
+    click_on "sign in with twitter"
+    User.find_by_uid('123545')
+  end
+
+  def stub_twitter_timeline
+    stub_request(:get, "https://api.twitter.com/1.1/search/tweets.json?count=100&q=%23motivation%20-rt")
+      .to_return(status: 200, body: "{}", headers: {})
+  end
+
+  def tweet_resolution_name
+    stub_request(:post, "https://api.twitter.com/1.1/statuses/update.json")
+      .to_return(status: 200, body: {id: 1}.to_json, headers: {})
+    click_on "Tweet This"
+  end
+
+  def expect_tweet_to_be_posted_to_twitter(body:)
+    expect(WebMock).to have_requested(:post, "https://api.twitter.com/1.1/statuses/update.json")
+      .with(body: { status: body })
+  end
+end


### PR DESCRIPTION
This completes [waffle card 10](https://waffle.io/davemaurer/resolutionary/cards/56045f118a19da3700d45a89)

We have decided to start actually writing tests, so this was the first feature
on the app that was test driven. The helper methods in the tests are a bit
dense, as we needed to jump through some hoops to mock out Twitter, and we
don't yet have enough context to figure out a better way to extract this out
and have it be a bit less noisy. At the very least, the test itself
demonstrates intent pretty well.

The feature was fairly straightforward to implement, and I don't think there
was much that stood out as weird. We learned about keyword arguments, which we
hadn't seen before, and learned how to use. We also stumbled a little bit when
we realized that even when we're making an expectation on a request having been
made, we still need to stub it before the request is actually made, since
WebMock doesn't know to allow it.
